### PR TITLE
specify required unixodbc version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Building
 
-1. Install unixodbc.
+1. Install unixodbc >= 2.3.0
 2. Download Poco source
 3. Run ```./configure --static --minimal --no-tests --cflags=-fPIC```
 4. Run ```make && make install```


### PR DESCRIPTION
when building on older unixodbc, the following error appear

```
clickhouse-odbc/driver/environment.h:49:24: error: ‘SQL_OV_ODBC3_80’ was not declared in this scope

     int odbc_version = SQL_OV_ODBC3_80;
```

I yet haven't found an elegant way how to check odbc version in CMake, let us just document it in README