### PR TITLE
cmake check for unixodbc version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ message(STATUS "Using Poco: ${Poco_INCLUDE_DIRS} : ${Poco_Foundation_LIBRARY},${
 # === find_poco_end ===
 
 include (contrib/poco/cmake/FindODBC.cmake)
+include (cmake/Modules/CheckODBCversion.cmake)
 
 message (STATUS "Building for: ${CMAKE_SYSTEM} ${CMAKE_SYSTEM_PROCESSOR} ${CMAKE_LIBRARY_ARCHITECTURE}")
 

--- a/cmake/Modules/CheckODBCversion.cmake
+++ b/cmake/Modules/CheckODBCversion.cmake
@@ -1,0 +1,16 @@
+FILE(WRITE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/conftest.c"
+  "#include <sqlext.h>                   \n"
+  "void main(void){                      \n"
+  "  int odbc_version = SQL_OV_ODBC3_80; \n"
+  "}                                       "
+  )
+
+EXECUTE_PROCESS(COMMAND ${CMAKE_C_COMPILER} conftest.c -I${ODBC_INCLUDE_DIRECTORIES}
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp
+  OUTPUT_VARIABLE OUTPUT
+  RESULT_VARIABLE RESULT
+  ERROR_VARIABLE ERROR)
+
+IF(RESULT)
+  MESSAGE(FATAL_ERROR "unixodbc >= 2.3.0 required.")
+ENDIF(RESULT)


### PR DESCRIPTION
at least ubuntu trusty is shipped with older unixodbc. so, we should check not only for presense of unixodbc, but also for certain version