### PR TITLE
bundle visual c++ redistributable into installer

### DIFF
--- a/vs/installer32/Product.wxs
+++ b/vs/installer32/Product.wxs
@@ -13,6 +13,7 @@
     <?define DLL_PATH = "../x64/$(var.Configuration)" ?>
     <?define POCO_FOUNDATION = "PocoFoundation64.dll" ?>
     <?define POCO_NET = "PocoNet64.dll" ?>
+    <?define CrtMergeModule = "$(env.CommonProgramFiles)\Merge Modules\Microsoft_VC140_CRT_x64.msm" ?>
     <?define ANSI_ID = "568F7B5A-6943-4B87-AB67-51E52B91607F" ?>
     <?define POCOLIB_ID = "D771CE33-985F-4C0B-ADE1-629115BEA253" ?>
     <?define PRODUCT_ID= "D77FCBEA-C3A9-442C-8055-83CBDB57009B" ?>
@@ -25,6 +26,7 @@
     <?define DLL_PATH = "../$(var.Configuration)" ?>
     <?define POCO_FOUNDATION = "PocoFoundation.dll" ?>
     <?define POCO_NET = "PocoNet.dll" ?>
+    <?define CrtMergeModule = "$(env.CommonProgramFiles)\Merge Modules\Microsoft_VC140_CRT_x86.msm" ?>
     <?define ANSI_ID = "5DFFB4E6-D747-4080-B733-69763772485C" ?>
     <?define POCOLIB_ID = "611EDC2C-2617-485E-81BE-2A9B4664E7BC" ?>
     <?define PRODUCT_ID= "9FCA44DB-6963-4EBF-87A6-279331C139EB" ?>
@@ -125,6 +127,7 @@
           </Component>
           </Directory>
       </Directory>
+      <Merge Id="CRT" Language="0" SourceFile="$(var.CrtMergeModule)" DiskId="1" />
     </Directory>
 
     <!-- Features -->
@@ -141,6 +144,9 @@
                Level="1" >
         <ComponentRef Id="UnicodeDriver" />
         <ComponentRef Id="PocoLibs" />
+      </Feature>
+      <Feature Id="CRT" AllowAdvertise="no" Display="hidden" Level="1" Title="Microsoft Visual C++ 2015 Runtime Components">
+        <MergeRef Id="CRT"/>
       </Feature>
     </Feature>
 

--- a/vs/installer64/Product.wxs
+++ b/vs/installer64/Product.wxs
@@ -13,6 +13,7 @@
     <?define DLL_PATH = "../x64/$(var.Configuration)" ?>
     <?define POCO_FOUNDATION = "PocoFoundation64.dll" ?>
     <?define POCO_NET = "PocoNet64.dll" ?>
+    <?define CrtMergeModule = "$(env.CommonProgramFiles)\Merge Modules\Microsoft_VC140_CRT_x64.msm" ?>
     <?define ANSI_ID = "568F7B5A-6943-4B87-AB67-51E52B91607F" ?>
     <?define POCOLIB_ID = "D771CE33-985F-4C0B-ADE1-629115BEA253" ?>
     <?define PRODUCT_ID= "D77FCBEA-C3A9-442C-8055-83CBDB57009B" ?>
@@ -25,6 +26,7 @@
     <?define DLL_PATH = "../$(var.Configuration)" ?>
     <?define POCO_FOUNDATION = "PocoFoundation.dll" ?>
     <?define POCO_NET = "PocoNet.dll" ?>
+    <?define CrtMergeModule = "$(env.CommonProgramFiles)\Merge Modules\Microsoft_VC140_CRT_x86.msm" ?>
     <?define ANSI_ID = "5DFFB4E6-D747-4080-B733-69763772485C" ?>
     <?define POCOLIB_ID = "611EDC2C-2617-485E-81BE-2A9B4664E7BC" ?>
     <?define PRODUCT_ID= "9FCA44DB-6963-4EBF-87A6-279331C139EB" ?>
@@ -125,6 +127,7 @@
           </Component>
           </Directory>
       </Directory>
+      <Merge Id="CRT" Language="0" SourceFile="$(var.CrtMergeModule)" DiskId="1" />
     </Directory>
 
     <!-- Features -->
@@ -141,6 +144,9 @@
                Level="1" >
         <ComponentRef Id="UnicodeDriver" />
         <ComponentRef Id="PocoLibs" />
+      </Feature>
+      <Feature Id="CRT" AllowAdvertise="no" Display="hidden" Level="1" Title="Microsoft Visual C++ 2015 Runtime Components">
+        <MergeRef Id="CRT"/>
       </Feature>
     </Feature>
 


### PR DESCRIPTION
it seems AppVeyor is not enabled anymore for this repo.


without "bundled" CRT an installation fails on "clean" computer (which does not have Visual Studio installed)