### PR TITLE
Fixed problem in multiuser environments when only one user can really…

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ sudo apt install unixodbc-dev
 ```bash
 mkdir -p build; cd build && cmake .. && make -j $(nproc || sysctl -n hw.ncpu || echo 2)
 ```
+Please use cmake3 to build the project on CentOS 7. You can install it with `yum install cmake3`.
 
 2. clickhouse-odbc.so will be at ```build/driver/clickhouse-odbc.so```
 

--- a/driver/environment.h
+++ b/driver/environment.h
@@ -3,6 +3,8 @@
 #include "diagnostics.h"
 
 #include <stdio.h>
+#include <unistd.h>
+#include <pwd.h>
 
 #include <map>
 #include <stdexcept>
@@ -34,7 +36,15 @@ struct Environment
     Environment()
     {
 #if defined (_unix_)
+        struct passwd *pw;
+        uid_t uid;
         std::string stderr_path = "/tmp/clickhouse-odbc-stderr";
+        uid = geteuid ();
+        pw = getpwuid (uid);
+        if (pw)
+        {
+            stderr_path += "." + std::string(pw->pw_name);
+        }
         if (!freopen(stderr_path.c_str(), "w", stderr))
             throw std::logic_error("Cannot freopen stderr.");
 #endif


### PR DESCRIPTION
For some reason STDERR is redirected to the file which is `/tmp/clickhouse-odbc-stderr` by default. If different users will use clickhouse odbc driver then only first user who first created the file will be able to use the driver. All other users will see the error:
```
[IM004][unixODBC][Driver Manager]Driver's SQLAllocHandle on SQL_HANDLE_HENV failed
```
This error is shown due to the  inability to `freopen` `/tmp/clickhouse-odbc-stderr`.

I just added username to the filename. For example it might look `/tmp/clickhouse-odbc-stderr.vasyapup`. Each user will have its own file with my fix. 

Another option is to make the file world writable, which is not good security practice.