### PR TITLE
Update odbc.cpp

### DIFF
--- a/driver/odbc.cpp
+++ b/driver/odbc.cpp
@@ -235,7 +235,7 @@ RETCODE SQL_API SQLColAttribute(HSTMT statement_handle,
                     if (column_info.fixed_size)
                         num_value = column_info.fixed_size * SIZEOF_CHAR;
                     else
-                        num_value = column_info.display_size * SIZEOF_CHAR;
+                        num_value = 32768 * SIZEOF_CHAR;
                 }
                 else
                 {


### PR DESCRIPTION
 Насильно ставит длину строк переменной длины равную 32768, иначе драйвер обрезает ее.