### PR TITLE
Make query to /query?... instead of /?...

### DIFF
--- a/driver/statement.cpp
+++ b/driver/statement.cpp
@@ -59,8 +59,7 @@ void Statement::sendRequest(IResultMutatorPtr mutator) {
     request.setChunkedTransferEncoding(true);
     request.setCredentials("Basic", user_password_base64.str());
     request.setURI(
-        "/?database=" + connection.getDatabase() + "&default_format=ODBCDriver2"); /// TODO Ability to transfer settings. TODO escaping
-
+        "/query?database=" + connection.getDatabase() + "&default_format=ODBCDriver2"); /// TODO Ability to transfer settings. TODO escaping
     request.set("User-Agent", "clickhouse-odbc/" VERSION_STRING " (" CMAKE_SYSTEM ")"
 #if defined(UNICODE)
         " UNICODE"


### PR DESCRIPTION
If there is some kind of balancer between the client and the ClickHouse server, it may be a case that it occupies `/` for some stuff of its own, thus it is better to make request to a more specific URI `/query`. To the best of my knowledge, all regular ClickHouse installations do not distinguish POST-requests to `/` and to `/query`.