### PR TITLE
Only set OPENSSL_ROOT_DIR if not defined

### DIFF
--- a/cmake/find_ssl.cmake
+++ b/cmake/find_ssl.cmake
@@ -13,7 +13,9 @@ endif ()
 
 if (NOT USE_INTERNAL_SSL_LIBRARY)
     if (APPLE)
-        set (OPENSSL_ROOT_DIR "/usr/local/opt/openssl")
+        if (NOT DEFINED OPENSSL_ROOT_DIR)
+            set (OPENSSL_ROOT_DIR "/usr/local/opt/openssl")
+         endif ()
         # https://rt.openssl.org/Ticket/Display.html?user=guest&pass=guest&id=2232
         if (USE_STATIC_LIBRARIES)
             message(WARNING "Disable USE_STATIC_LIBRARIES if you have linking problems with OpenSSL on MacOS")

--- a/cmake/find_ssl.cmake
+++ b/cmake/find_ssl.cmake
@@ -13,9 +13,7 @@ endif ()
 
 if (NOT USE_INTERNAL_SSL_LIBRARY)
     if (APPLE)
-        if (NOT DEFINED OPENSSL_ROOT_DIR)
-            set (OPENSSL_ROOT_DIR "/usr/local/opt/openssl")
-         endif ()
+        set (OPENSSL_ROOT_DIR "/usr/local/opt/openssl" CACHE INTERNAL "")
         # https://rt.openssl.org/Ticket/Display.html?user=guest&pass=guest&id=2232
         if (USE_STATIC_LIBRARIES)
             message(WARNING "Disable USE_STATIC_LIBRARIES if you have linking problems with OpenSSL on MacOS")


### PR DESCRIPTION
This helps with the use of a non-standard OpenSSL location.