### PR TITLE
Docker tests

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,8 @@ FROM yandex/clickhouse-server
 # image to build & test clickhouse odbc on ubuntu & docker
 # install all needed build & test dependancies
 
+# docker build . -t clickhouse-odbc-tester
+
 RUN apt-get update -y \
     && env DEBIAN_FRONTEND=noninteractive \
     && BUILD_PACKAGES="build-essential ninja-build libiodbc2-dev cmake git libltdl-dev perl libdbi-perl libdbd-odbc-perl python python-pyodbc" \
@@ -14,7 +16,7 @@ RUN git clone --recursive https://github.com/yandex/clickhouse-odbc \
 
 RUN mkdir -p clickhouse-odbc/build \
     && cd clickhouse-odbc/build \
-    && cmake -G Ninja -DTEST_DSN=clickhouse_localhost .. \
+    && cmake -G Ninja -DTEST_DSN=clickhouse_localhost -DTEST_DSN_W=clickhouse_localhost_w .. \
     && ninja
 
 RUN ln -s /clickhouse-odbc/build/driver/libclickhouseodbc.so /usr/local/lib/libclickhouseodbc.so \
@@ -22,6 +24,10 @@ RUN ln -s /clickhouse-odbc/build/driver/libclickhouseodbc.so /usr/local/lib/libc
     && echo '' >> ~/.odbc.ini \
     && echo '[clickhouse_localhost]' >> ~/.odbc.ini \
     && echo 'Driver=/usr/local/lib/libclickhouseodbc.so' >> ~/.odbc.ini \
+    && echo 'url=http://localhost' >> ~/.odbc.ini \
+    && echo '' >> ~/.odbc.ini \
+    && echo '[clickhouse_localhost_w]' >> ~/.odbc.ini \
+    && echo 'Driver=/usr/local/lib/libclickhouseodbcw.so' >> ~/.odbc.ini \
     && echo 'url=http://localhost' >> ~/.odbc.ini
 
 # put the test into docker-entrypoint-initdb.d to run the tests on container initialization

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,34 @@
+FROM yandex/clickhouse-server
+
+# image to build & test clickhouse odbc on ubuntu & docker
+# install all needed build & test dependancies
+
+RUN apt-get update -y \
+    && env DEBIAN_FRONTEND=noninteractive \
+    && BUILD_PACKAGES="build-essential ninja-build libiodbc2-dev cmake git libltdl-dev perl libdbi-perl libdbd-odbc-perl python python-pyodbc" \
+    && RUNTIME_PACKAGES="unixodbc" \
+    && apt-get install -y $BUILD_PACKAGES $RUNTIME_PACKAGES
+
+RUN git clone --recursive https://github.com/yandex/clickhouse-odbc \
+    && ( cd clickhouse-odbc/contrib && git clone https://github.com/nanodbc/nanodbc )
+
+RUN mkdir -p clickhouse-odbc/build \
+    && cd clickhouse-odbc/build \
+    && cmake -G Ninja -DTEST_DSN=clickhouse_localhost .. \
+    && ninja
+
+RUN ln -s /clickhouse-odbc/build/driver/libclickhouseodbc.so /usr/local/lib/libclickhouseodbc.so \
+    && ln -s /clickhouse-odbc/build/driver/libclickhouseodbcw.so /usr/local/lib/libclickhouseodbcw.so \
+    && echo '' >> ~/.odbc.ini \
+    && echo '[clickhouse_localhost]' >> ~/.odbc.ini \
+    && echo 'Driver=/usr/local/lib/libclickhouseodbc.so' >> ~/.odbc.ini \
+    && echo 'url=http://localhost' >> ~/.odbc.ini
+
+# put the test into docker-entrypoint-initdb.d to run the tests on container initialization
+# it just was the simplest
+RUN echo '#!/bin/bash' > /docker-entrypoint-initdb.d/run_ctest.sh \
+    && echo 'cd clickhouse-odbc/build' >> /docker-entrypoint-initdb.d/run_ctest.sh \
+    && echo 'ctest -V' >> /docker-entrypoint-initdb.d/run_ctest.sh
+
+# run the tests build time too:
+RUN bash -c '/entrypoint.sh bash -c "echo ok"'

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -1,0 +1,45 @@
+FROM centos:7
+
+# image to build & test clickhouse odbc on centos7 & docker
+# install all needed build & test dependancies
+
+# docker build -f Dockerfile.centos7 . -t clickhouse-odbc-tester-centos7
+# docker run --rm -it clickhouse-odbc-tester-centos7 bash
+
+RUN yum install -y centos-release-scl  epel-release \
+    && yum install -y devtoolset-7 cmake3 git ninja-build libtool-ltdl-devel unixODBC-devel perl-Test-Base perl-DBD-ODBC python-pip python-devel --nogpgcheck \
+    && source scl_source enable devtoolset-7 \
+    && pip install pyodbc
+
+# altinity rpm
+RUN curl -s https://packagecloud.io/install/repositories/altinity/clickhouse/script.rpm.sh | bash \
+    && yum install -y clickhouse-server clickhouse-client
+
+RUN git clone --recursive https://github.com/yandex/clickhouse-odbc \
+    && ( cd clickhouse-odbc/contrib && git clone https://github.com/nanodbc/nanodbc )
+
+RUN mkdir -p clickhouse-odbc/build \
+    && cd clickhouse-odbc/build \
+    && source scl_source enable devtoolset-7 \
+    && cmake3 -G Ninja -DTEST_DSN=clickhouse_localhost -DTEST_DSN_W=clickhouse_localhost_w .. \
+    && ninja-build
+
+RUN ln -s /clickhouse-odbc/build/driver/libclickhouseodbc.so /usr/local/lib/libclickhouseodbc.so \
+    && ln -s /clickhouse-odbc/build/driver/libclickhouseodbcw.so /usr/local/lib/libclickhouseodbcw.so \
+    && echo '' >> ~/.odbc.ini \
+    && echo '[clickhouse_localhost]' >> ~/.odbc.ini \
+    && echo 'Driver=/usr/local/lib/libclickhouseodbc.so' >> ~/.odbc.ini \
+    && echo 'url=http://localhost' >> ~/.odbc.ini \
+    && echo '' >> ~/.odbc.ini \
+    && echo '[clickhouse_localhost_w]' >> ~/.odbc.ini \
+    && echo 'Driver=/usr/local/lib/libclickhouseodbcw.so' >> ~/.odbc.ini \
+    && echo 'url=http://localhost' >> ~/.odbc.ini
+
+# bit dirty way to start clickhouse via init.d scripts
+RUN /etc/init.d/clickhouse-server start \
+    && cd clickhouse-odbc/build \
+    && ctest3 -V
+
+ENTRYPOINT /etc/init.d/clickhouse-server start && sh $@
+
+CMD bash

--- a/driver/ut/nano.cpp
+++ b/driver/ut/nano.cpp
@@ -124,6 +124,7 @@ void run_test(nanodbc::string const & connection_string) {
             auto results = execute(connection, NANODBC_TEXT("select * from simple_test;"));
             show(results);
         }
+        execute(connection, NANODBC_TEXT("CREATE DATABASE IF NOT EXISTS test;"));
         execute(connection, NANODBC_TEXT("DROP TABLE IF EXISTS test.strings;"));
         execute(connection, NANODBC_TEXT("CREATE TABLE test.strings (id UInt64, str String, dt DateTime DEFAULT now()) engine = Log;"));
         execute(connection, NANODBC_TEXT("INSERT INTO test.strings SELECT number, hex(number+100000), 1 FROM system.numbers LIMIT 100;"));


### PR DESCRIPTION
Added docker build scripts to build & test clickhouse-odbc in ubuntu & centos. 

I've also fixed one test, failing due to absence of database.

Currently those tests are failing in that builds:

**ubuntu**:
 
`3 - clickhouse-odbc-nano-w (Failed)` - some encoding problems. clickhouse get one letter 's' instead of query. Maybe related to NANODBC_ENABLE_UNICODE flag

**centos**:
`2 - clickhouse-odbc-nano (Failed)` & `3 - clickhouse-odbc-nano-w (Failed)` -  both failing to start with exception:
```../contrib/nanodbc/nanodbc/nanodbc.cpp:772: S100: [unixODBC][Driver Manager]Invalid attribute value``` 
https://github.com/nanodbc/nanodbc/blob/107d6c043c8171b72496d55b46932d1ea946ebc0/nanodbc/nanodbc.cpp#L772 
(some API versions mismatch?)


10 - iusql-default (Failed): something strange for some reason that fails, and exception that default user is not known (clickhouse-client is of with user default).
```
[root@5597f714e696 clickhouse-server]# echo select 123456+456789 | /usr/bin/iusql clickhouse_localhost default  | grep 580245
[ISQL]ERROR: Could not SQLExecute
[root@5597f714e696 clickhouse-server]# tail -n 20 /var/log/clickhouse-server/clickhouse-server.log 
2019.06.06 11:41:06.747955 [ 51 ] {} <Trace> HTTPHandler-factory: HTTP Request for HTTPHandler-factory. Method: POST, Address: 127.0.0.1:44380, User-Agent: clickhouse-odbc/1.0.0.20190523 (Linux-5.0.0-050000-generic), Content Type: , Transfer Encoding: chunked
2019.06.06 11:41:06.748059 [ 51 ] {} <Trace> HTTPHandler: Request URI: /query?database=default&default_format=ODBCDriver2
2019.06.06 11:41:06.748160 [ 51 ] {} <Debug> MemoryTracker: Peak memory usage (for query): 0.00 B.
2019.06.06 11:41:06.748205 [ 51 ] {} <Error> HTTPHandler: Code: 192, e.displayText() = DB::Exception: Unknown user default, Stack trace:

0. clickhouse-server(StackTrace::StackTrace()+0x16) [0x6834a66]
1. clickhouse-server(DB::Exception::Exception(std::string const&, int)+0x1f) [0x317311f]
2. clickhouse-server(DB::UsersManager::authorizeAndGetUser(std::string const&, std::string const&, Poco::Net::IPAddress const&) const+0x60e) [0x5fb3b7e]
3. clickhouse-server(DB::Context::setUser(std::string const&, std::string const&, Poco::Net::SocketAddress const&, std::string const&)+0x66) [0x5e5e346]
4. clickhouse-server(DB::HTTPHandler::processQuery(Poco::Net::HTTPServerRequest&, HTMLForm&, Poco::Net::HTTPServerResponse&, DB::HTTPHandler::Output&)+0x566) [0x3184e06]
5. clickhouse-server(DB::HTTPHandler::handleRequest(Poco::Net::HTTPServerRequest&, Poco::Net::HTTPServerResponse&)+0x458) [0x3188af8]
6. clickhouse-server(Poco::Net::HTTPServerConnection::run()+0x2a9) [0x6a7aec9]
7. clickhouse-server(Poco::Net::TCPServerConnection::start()+0xf) [0x6a75e9f]
8. clickhouse-server(Poco::Net::TCPServerDispatcher::run()+0xe5) [0x6a76585]
9. clickhouse-server(Poco::PooledThread::run()+0x81) [0x6b97ae1]
10. clickhouse-server(Poco::ThreadImpl::runnableEntry(void*)+0x38) [0x6b938a8]
11. clickhouse-server() [0x73c681f]
12. /lib64/libpthread.so.0(+0x7dd5) [0x7f0e41af1dd5]
13. /lib64/libc.so.6(clone+0x6d) [0x7f0e40df3ead]
 (version 19.7.3.1)
```

Unicode driver on centos dies with isql & bad query:
```
iusql clickhouse_localhost_w
+---------------------------------------+
| Connected!                            |
|                                       |
| sql-statement                         |
| help [tablename]                      |
| quit                                  |
|                                       |
+---------------------------------------+
SQL> select 1+2;
+-----------+

| plus(1, 2)|

+-----------+

| 3         |
+-----------+

SQLRowCount returns 1
1 rows fetched
SQL> blablabla
Segmentation fault (core dumped)
```
